### PR TITLE
Upgrade react-redux to v8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change history for stripes-vendor-dll
 
+## 2.0.0 IN PROGRESS
+* Upgrade `react-redux` to `v8`. Refs STRIPES-834.
+
 ## [1.0.0](https://github.com/folio-org/stripes-vendor-dll/tree/v1.0.0) (2021-01-06)
 
 * Initial setup.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-vendor-dll",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Stripes Vendor Dll",
   "main": "output/stripesVendorDll.js",
   "publishConfig": {
@@ -20,7 +20,7 @@
     "react": "~16.13.1",
     "react-dom": "~16.13.1",
     "react-intl": "^5.7.0",
-    "react-redux": "^5.1.1",
+    "react-redux": "^8.0.5",
     "react-router": "^5.2.0",
     "react-router-dom": "^5.2.0",
     "redux": "^3.7.2"


### PR DESCRIPTION
- Refs https://issues.folio.org/browse/STRIPES-834.
- Upgrade will be happening across all of Stripes framework and modules that reference react-redux.
- v7 to v8 is a very harmless upgrade and is only considered breaking since they removed a few rarely used functions (which I confirmed we don't use). See https://github.com/reduxjs/react-redux/releases/tag/v8.0.0 for more details.